### PR TITLE
[Autopilot] approval for rule pg/postgresql-volume-resize-pvc-4cc86c52-84da-4487-930c-fb66a76c7e72 rule: postgresql-volume-resize

### DIFF
--- a/workloads/postgresql-volume-resize-pvc-4cc86c52-84da-4487-930c-fb66a76c7e72-2b44334c-978d-4c63-9b3a-72bc72df497b.yaml
+++ b/workloads/postgresql-volume-resize-pvc-4cc86c52-84da-4487-930c-fb66a76c7e72-2b44334c-978d-4c63-9b3a-72bc72df497b.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-4cc86c52-84da-4487-930c-fb66a76c7e72
+    rule: postgresql-volume-resize
+  name: postgresql-volume-resize-pvc-4cc86c52-84da-4487-930c-fb66a76c7e72
+  namespace: pg
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: postgresql-volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 5Gi to 10Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: postgres-data
+      namespace: pg
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: postgres-84ff5769cd
+        uid: 3ea1dd9f-703f-4865-9bf2-e81cc6acba48
+      uid: pvc-4cc86c52-84da-4487-930c-fb66a76c7e72
+  lastProcessTimestamp: "2020-09-23T20:51:17Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __postgresql-volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 5Gi to 10Gi
 
#### What objects will get affected

- PersistentVolumeClaim pg/postgres-data (pvc-4cc86c52-84da-4487-930c-fb66a76c7e72)
  - Object Owner(s):
    - ReplicaSet postgres-84ff5769cd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
